### PR TITLE
Add comprehensive tests for all FastAPI endpoints

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,34 @@
+# FFAPI Application Analysis
+
+## Overview
+- **Framework:** FastAPI application providing web UI pages and API endpoints for media processing tasks.
+- **Key Capabilities:**
+  - Static file publishing and retention management for generated media.
+  - Web dashboards for downloads, log viewing, and FFmpeg diagnostics.
+  - Endpoints covering media composition, concatenation, probing, and running custom FFmpeg commands.
+- **Supporting Infrastructure:** Uses configurable directories (`PUBLIC_DIR`, `WORK_DIR`, `LOGS_DIR`) and environment variables to control retention and public URL behavior.
+
+## Architectural Highlights
+- Centralized logging configuration writes simultaneously to console and persistent log file, with helper `_flush_logs()` to reduce buffering delays.
+- `publish_file` encapsulates final file handling, ensuring atomic moves and optional public URL generation.
+- UI pages are assembled as HTML strings inside route handlers, avoiding template dependencies but making layout changes code-heavy.
+
+## Strengths
+- **Operational Visibility:** `/ffmpeg` page aggregates FFmpeg version info and recent application logs, improving debugging experience.
+- **Resilience:** Download helper retries with exponential backoff, supports resuming partial downloads, and cleans up partial files after repeated failures.
+- **Safety:** Path validation in `/logs/view` prevents directory traversal attacks when inspecting stored log files.
+
+## Risks & Limitations
+- **Monolithic Module:** `app/main.py` houses all routes, utilities, and HTML, which complicates maintenance and testing as the feature set grows.
+- **Synchronous Downloads:** `download_file` uses synchronous `requests`, blocking the event loop when large files are fetched. Consider running in a threadpool or switching to `httpx` with async streaming.
+- **HTML Maintainability:** Inline HTML generation lacks templating support or component reuse, increasing risk of inconsistencies across pages.
+- **Startup Logging:** `sys.stdout.reconfigure` assumes an IO object supporting that method; this fails under environments that wrap stdout differently (e.g., some WSGI servers).
+- **Security Controls:** Custom FFmpeg command endpoint relies on caller-provided templates without explicit sanitation, which could permit dangerous command execution if exposed beyond trusted users.
+
+## Suggested Improvements
+1. **Refactor Structure:** Break `app/main.py` into modules (e.g., `routes`, `services`, `templates`) and introduce FastAPI routers for clearer separation of concerns.
+2. **Adopt Templates:** Leverage Jinja2 templates or a lightweight frontend to manage repeated UI elements like navigation and branding.
+3. **Async-Friendly IO:** Replace blocking `requests` calls with async equivalents or execute them via `run_in_threadpool` to keep the server responsive during large downloads.
+4. **Command Safeguards:** Implement allow-lists or sandboxing for `/v1/run-ffmpeg-command` to mitigate arbitrary command execution, especially if the service will be multi-tenant.
+5. **Configuration Validation:** Provide startup checks (via Pydantic settings) to validate directory paths and environment variables, failing fast when misconfigured.
+

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,6 @@
+# Test Execution Summary
+
+## Test Run: Pytest
+- **Command:** `pytest`
+- **Result:** Passed (19 tests)
+- **Notes:** Full FastAPI endpoint suite passes, including HTML pages, media workflows, and ffprobe utilities with stubbed dependencies.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for FastAPI application."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,407 @@
+import asyncio
+import importlib
+import io
+import json
+import os
+import shutil
+import sys
+from itertools import count
+from pathlib import Path
+from typing import Tuple
+from urllib.parse import urlencode
+
+import pytest
+from fastapi import UploadFile
+from starlette.datastructures import Headers
+
+
+class DummyCompletedProcess:
+    def __init__(self, returncode: int = 0, stdout=None, stderr=None):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+async def _call_app(app, method: str, path: str, *, headers=None, body: bytes = b"", query: str = "") -> Tuple[int, dict, bytes]:
+    headers = headers or []
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "method": method,
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": query.encode("ascii"),
+        "headers": [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in headers],
+        "client": ("testclient", 123),
+        "server": ("testserver", 80),
+        "scheme": "http",
+    }
+
+    request_body = body
+    request_complete = False
+    response_status = None
+    response_headers = []
+    response_body = bytearray()
+
+    async def receive():
+        nonlocal request_body, request_complete
+        if request_complete:
+            return {"type": "http.disconnect"}
+        request_complete = True
+        return {"type": "http.request", "body": request_body, "more_body": False}
+
+    async def send(message):
+        nonlocal response_status, response_headers, response_body
+        if message["type"] == "http.response.start":
+            response_status = message["status"]
+            response_headers = message.get("headers", [])
+        elif message["type"] == "http.response.body":
+            response_body.extend(message.get("body", b""))
+
+    await app(scope, receive, send)
+
+    headers_dict = {k.decode("latin-1"): v.decode("latin-1") for k, v in response_headers}
+    return response_status or 500, headers_dict, bytes(response_body)
+
+
+def call_app(app, method: str, path: str, *, headers=None, body: bytes = b"", query: str = "") -> Tuple[int, dict, bytes]:
+    return asyncio.run(_call_app(app, method, path, headers=headers, body=body, query=query))
+
+
+@pytest.fixture(scope="session")
+def app_module(tmp_path_factory: pytest.TempPathFactory):
+    base = tmp_path_factory.mktemp("data")
+    env = {
+        "PUBLIC_DIR": str(base / "public"),
+        "WORK_DIR": str(base / "work"),
+        "LOGS_DIR": str(base / "logs"),
+        "PUBLIC_BASE_URL": "http://example.com",
+        "RETENTION_DAYS": "7",
+    }
+    for key, value in env.items():
+        os.environ[key] = value
+
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    module_name = "app.main"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    module = importlib.import_module(module_name)
+    return module
+
+
+@pytest.fixture()
+def patched_app(app_module, monkeypatch, tmp_path):
+    publish_root = tmp_path / "published"
+    publish_root.mkdir(parents=True, exist_ok=True)
+    counter = count()
+
+    def fake_publish_file(src: Path, ext: str):
+        dst = publish_root / f"file_{next(counter)}{ext}"
+        src_path = Path(src)
+        if src_path.exists():
+            dst.write_bytes(src_path.read_bytes())
+        else:
+            dst.write_bytes(b"")
+        return {"dst": str(dst), "url": f"http://example.com/{dst.name}", "rel": f"/files/{dst.name}"}
+
+    def fake_download_to(url: str, dest: Path, headers=None, max_retries: int = 3, chunk_size: int = 1024 * 1024):
+        dest_path = Path(dest)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_bytes(f"downloaded from {url}".encode("utf-8"))
+
+    def fake_save_log(*args, **kwargs):
+        return None
+
+    def fake_run(cmd, *args, **kwargs):
+        text_mode = kwargs.get("text", False)
+        capture_output = kwargs.get("capture_output", False)
+        stdout_target = kwargs.get("stdout")
+        stderr_target = kwargs.get("stderr")
+
+        if isinstance(cmd, list):
+            command = cmd
+        else:
+            command = cmd.split()
+
+        def write_stream(target, data: bytes | str):
+            if target is None:
+                return
+            try:
+                target.write(data)
+            except TypeError:
+                if isinstance(data, str):
+                    target.write(data.encode("utf-8"))
+                else:
+                    target.write(data.decode("utf-8"))
+
+        if command and command[0] == "ffmpeg" and len(command) > 1 and command[1] == "-version":
+            stdout = "ffmpeg version n4.0" if text_mode else b"ffmpeg version n4.0"
+            return DummyCompletedProcess(returncode=0, stdout=stdout, stderr="" if text_mode else b"")
+
+        if command and command[0] == "ffprobe":
+            payload = json.dumps({"format": {"format_name": "fake"}, "streams": []}).encode("utf-8")
+            return DummyCompletedProcess(returncode=0, stdout=payload, stderr=b"")
+
+        output_path = None
+        for token in reversed(command):
+            if token.startswith("-"):
+                break
+            output_path = Path(token)
+            break
+        if output_path is not None:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"fake output")
+
+        data_bytes = b"run"
+        data_text = "run"
+        if stdout_target is not None:
+            write_stream(stdout_target, data_text if text_mode else data_bytes)
+        if stderr_target is not None:
+            write_stream(stderr_target, data_text if text_mode else data_bytes)
+
+        stdout_value = "" if text_mode else b""
+        if capture_output:
+            stdout_value = "" if text_mode else b""
+        return DummyCompletedProcess(returncode=0, stdout=stdout_value, stderr="" if text_mode else b"")
+
+    monkeypatch.setattr(app_module, "publish_file", fake_publish_file)
+    monkeypatch.setattr(app_module, "_download_to", fake_download_to)
+    monkeypatch.setattr(app_module, "save_log", fake_save_log)
+    monkeypatch.setattr(app_module.subprocess, "run", fake_run)
+
+    for directory in (app_module.PUBLIC_DIR, app_module.LOGS_DIR, app_module.WORK_DIR):
+        if directory.exists():
+            shutil.rmtree(directory)
+        directory.mkdir(parents=True, exist_ok=True)
+
+    return app_module
+
+
+def test_root_redirects_to_downloads(patched_app):
+    status, headers, _ = call_app(patched_app.app, "GET", "/")
+    assert status in {301, 302, 307, 308}
+    assert headers["location"] == "/downloads"
+
+
+def test_downloads_page_lists_existing_files(patched_app):
+    day_dir = patched_app.PUBLIC_DIR / "20240101"
+    day_dir.mkdir(parents=True, exist_ok=True)
+    (day_dir / "example.txt").write_text("hello", encoding="utf-8")
+
+    status, _, body = call_app(patched_app.app, "GET", "/downloads")
+    assert status == 200
+    html = body.decode()
+    assert "20240101" in html
+    assert "example.txt" in html
+
+
+def test_logs_page_lists_entries(patched_app):
+    day_dir = patched_app.LOGS_DIR / "20240102"
+    day_dir.mkdir(parents=True, exist_ok=True)
+    (day_dir / "20240102_log.log").write_text("log line", encoding="utf-8")
+
+    status, _, body = call_app(patched_app.app, "GET", "/logs")
+    assert status == 200
+    html = body.decode()
+    assert "20240102" in html
+    assert "View" in html
+
+
+def test_view_log_endpoint(patched_app):
+    day_dir = patched_app.LOGS_DIR / "20240103"
+    day_dir.mkdir(parents=True, exist_ok=True)
+    (day_dir / "operation.log").write_text("details", encoding="utf-8")
+
+    status, _, body = call_app(
+        patched_app.app,
+        "GET",
+        "/logs/view",
+        query=urlencode({"path": "20240103/operation.log"}),
+    )
+    assert status == 200
+    assert body.decode() == "details"
+
+    status, _, _ = call_app(
+        patched_app.app,
+        "GET",
+        "/logs/view",
+        query=urlencode({"path": "../outside.log"}),
+    )
+    assert status == 400
+
+
+def test_ffmpeg_page_includes_version_and_auto_refresh(patched_app):
+    patched_app.APP_LOG_FILE.write_text("first line\nsecond line", encoding="utf-8")
+
+    status, _, body = call_app(
+        patched_app.app,
+        "GET",
+        "/ffmpeg",
+        query=urlencode({"auto_refresh": 120}),
+    )
+    assert status == 200
+    html = body.decode()
+    assert "ffmpeg version" in html
+    assert "Auto-refreshing every 60 seconds" in html
+
+
+def test_documentation_page_loads(patched_app):
+    status, _, body = call_app(patched_app.app, "GET", "/documentation")
+    assert status == 200
+    assert "FFAPI Ultimate - API Documentation" in body.decode()
+
+
+def test_health_endpoint(patched_app):
+    status, _, body = call_app(patched_app.app, "GET", "/health")
+    assert status == 200
+    assert json.loads(body.decode()) == {"ok": True}
+
+
+def test_static_file_serving(patched_app):
+    day_dir = patched_app.PUBLIC_DIR / "20240104"
+    day_dir.mkdir(parents=True, exist_ok=True)
+    file_path = day_dir / "asset.txt"
+    file_path.write_text("asset", encoding="utf-8")
+
+    status, _, body = call_app(
+        patched_app.app,
+        "GET",
+        f"/files/{day_dir.name}/{file_path.name}",
+    )
+    assert status == 200
+    assert body.decode() == "asset"
+
+
+def test_image_to_mp4_loop_as_json(patched_app):
+    upload = UploadFile(
+        file=io.BytesIO(b"\x89PNG\r\n\x1a\n"),
+        filename="image.png",
+        headers=Headers({"content-type": "image/png"}),
+    )
+    result = asyncio.run(patched_app.image_to_mp4_loop(upload, duration=5, as_json=True))
+    assert result["ok"] is True
+    assert result["file_url"].startswith("http://example.com/")
+
+
+def test_compose_from_binaries_with_all_inputs(patched_app):
+    video = UploadFile(file=io.BytesIO(b"video"), filename="video.mp4", headers=Headers({"content-type": "video/mp4"}))
+    audio = UploadFile(file=io.BytesIO(b"audio"), filename="audio.mp3", headers=Headers({"content-type": "audio/mpeg"}))
+    bgm = UploadFile(file=io.BytesIO(b"music"), filename="music.mp3", headers=Headers({"content-type": "audio/mpeg"}))
+    result = asyncio.run(
+        patched_app.compose_from_binaries(
+            video=video,
+            audio=audio,
+            bgm=bgm,
+            duration_ms=15000,
+            width=1280,
+            height=720,
+            fps=24,
+            bgm_volume=0.5,
+            as_json=True,
+        )
+    )
+    assert result["ok"] is True
+
+
+def test_compose_from_urls_as_json(patched_app):
+    job = patched_app.ComposeFromUrlsJob(
+        video_url="https://example.com/video.mp4",
+        audio_url="https://example.com/audio.mp3",
+        bgm_url="https://example.com/music.mp3",
+        duration_ms=10000,
+        width=640,
+        height=360,
+        fps=25,
+        bgm_volume=0.2,
+    )
+    result = patched_app.compose_from_urls(job, as_json=True)
+    assert result["ok"] is True
+
+
+def test_compose_from_tracks_as_json(patched_app):
+    job = patched_app.TracksComposeJob(
+        tracks=[
+            patched_app.Track(
+                id="video1",
+                type="video",
+                keyframes=[patched_app.Keyframe(url="https://example.com/video.mp4", timestamp=0, duration=5000)],
+            ),
+            patched_app.Track(
+                id="audio1",
+                type="audio",
+                keyframes=[patched_app.Keyframe(url="https://example.com/audio.mp3", timestamp=0, duration=5000)],
+            ),
+        ],
+        width=1280,
+        height=720,
+        fps=30,
+    )
+    result = patched_app.compose_from_tracks(job, as_json=True)
+    assert result["ok"] is True
+
+
+def test_video_concat_from_urls_as_json(patched_app):
+    job = patched_app.ConcatJob(
+        clips=[
+            "https://example.com/a.mp4",
+            "https://example.com/b.mp4",
+        ],
+        width=1920,
+        height=1080,
+        fps=30,
+    )
+    result = patched_app.video_concat_from_urls(job, as_json=True)
+    assert result["ok"] is True
+
+
+def test_video_concat_alias_requires_clips(patched_app):
+    job = patched_app.ConcatAliasJob(width=640, height=360, fps=30)
+    with pytest.raises(patched_app.HTTPException) as exc:
+        patched_app.video_concat_alias(job)
+    assert exc.value.status_code == 422
+
+
+def test_video_concat_alias_with_clips(patched_app):
+    job = patched_app.ConcatAliasJob(clips=["https://example.com/1.mp4", "https://example.com/2.mp4"], width=854, height=480, fps=30)
+    result = patched_app.video_concat_alias(job, as_json=True)
+    assert result["ok"] is True
+
+
+def test_run_ffmpeg_command_returns_outputs(patched_app):
+    job = patched_app.RendiJob(
+        input_files={"video": "https://example.com/input.mp4"},
+        output_files={"out": "result.mp4"},
+        ffmpeg_command="-i {{video}} {{out}}",
+    )
+    result = patched_app.run_rendi(job)
+    assert result["ok"] is True
+    assert "out" in result["outputs"]
+
+
+def test_probe_from_urls_returns_json(patched_app):
+    job = patched_app.ProbeUrlJob(url="https://example.com/video.mp4", show_streams=True, count_frames=True)
+    result = patched_app.probe_from_urls(job)
+    assert result["format"]["format_name"] == "fake"
+
+
+def test_probe_from_binary_returns_json(patched_app):
+    upload = UploadFile(file=io.BytesIO(b"binary"), filename="upload.mp4", headers=Headers({"content-type": "video/mp4"}))
+    result = asyncio.run(patched_app.probe_from_binary(upload, show_format=True, show_streams=True))
+    assert result["format"]["format_name"] == "fake"
+
+
+def test_probe_public_returns_json(patched_app):
+    day_dir = patched_app.PUBLIC_DIR / "20240105"
+    day_dir.mkdir(parents=True, exist_ok=True)
+    media = day_dir / "video.mp4"
+    media.write_bytes(b"fake")
+
+    result = patched_app.probe_public(
+        rel=f"{day_dir.name}/{media.name}",
+        show_format=True,
+        show_streams=True,
+    )
+    assert result["format"]["format_name"] == "fake"


### PR DESCRIPTION
## Summary
- replace the previous limited unit tests with an ASGI helper so HTTP pages can be exercised without TestClient
- add fixtures that stub out ffmpeg, downloads, and publishing so media endpoints can be verified deterministically
- cover every documented GET and POST route, including JSON-producing flows and the error case on the concat alias endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e68589ae7c832c95274ea74defc7aa